### PR TITLE
Overhaul to avoid direct mementoweb.org API calls

### DIFF
--- a/TimeTravelBot.ts
+++ b/TimeTravelBot.ts
@@ -1,17 +1,26 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction, Client, Message, GatewayIntentBits, ChatInputCommandInteraction, EmbedBuilder,
-    ContextMenuCommandBuilder, ApplicationCommandType, MessageContextMenuCommandInteraction } from "discord.js";
-import axios from "axios";
+    ContextMenuCommandBuilder, ApplicationCommandType, MessageContextMenuCommandInteraction, ButtonBuilder,
+    ActionRowBuilder, ButtonStyle, User, italic, BaseMessageOptions } from "discord.js";
+import { APIEmbedField } from "discord-api-types/v10";
 import { find } from "linkifyjs";
 import { BotInterface } from "../../BotInterface";
 import { readYamlConfig } from "../../utils/ConfigUtils";
 import { TimeTravelConfig } from "./TimeTravelConfig";
+import { TimeTravelProcessorResult, TimeTravelProcessor } from "./TimeTravelProcessor";
 
 export class TimeTravelBot implements BotInterface {
     intents: GatewayIntentBits[];
     commands: (SlashCommandBuilder | ContextMenuCommandBuilder)[];
 
     private static readonly OPT_URL = "url";
+    private static readonly BTN_USER_URL_MODAL = "timeTravel_btnUserUrlModal";
+    private static readonly BTN_USER_URL_DELETE = "timeTravel_btnUserUrlDelete";
+    private static readonly COLOR_SUCCESS = 0x00FF00;
+    private static readonly COLOR_FALLBACK = 0xFFCC00;
+    private static readonly COLOR_USER_ONLY = 0X40A6CE;
+    private static readonly AUTO_TIMEOUT = 2000;
+
     private slashTimeTravel!: SlashCommandBuilder;
     private contextTimeTravel!: ContextMenuCommandBuilder;
     private config!: TimeTravelConfig;
@@ -65,167 +74,154 @@ export class TimeTravelBot implements BotInterface {
     async handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
         const url = interaction.options.getString(TimeTravelBot.OPT_URL, true);
         try {
-            await interaction.deferReply();
-            console.log(`[TimeTravelBot] got URL: ${url}`);
+            console.log(`[TimeTravelBot] handleSlashCommand() got URL: ${url}`);
 
-            if (!TimeTravelBot.isValidUrl(url)) {
-                await interaction.editReply({
-                    embeds: [TimeTravelBot.createFailedEmbed(url, "Invalid URL.")]
+            const validUrl = TimeTravelBot.getValidUrl(url);
+            if (validUrl === null) {
+                await interaction.reply({
+                    embeds: [TimeTravelBot.createInvalidEmbed("Invalid URL", url)],
+                    ephemeral: true
                 });
                 return;
             }
 
-            await interaction.editReply({
-                embeds: [TimeTravelBot.createHoldEmbed(url)]
-            });
+            await interaction.deferReply();
+            const holdPromise = interaction.editReply(TimeTravelBot.createHoldEmbed(url));
 
-            const resultEmbed = await this.timeTravel(url);
-            await interaction.editReply({
-                embeds: [resultEmbed]
-            });
+            const result = await this.timeTravel(url);
+            await holdPromise;
+            await interaction.editReply(result);
         } catch (error) {
             console.error(`[TimeTravelBot] Got error handling slash command: ${error}`);
-            await interaction.editReply({
-                embeds: [TimeTravelBot.createFailedEmbed(url, error)]
-            });
-        }
-    }
-
-    async timeTravel(originalUrl: string): Promise<EmbedBuilder> {
-        console.log(`[TimeTravelBot] Attempting to time travel ${originalUrl}`);
-
-        const fullUrl = `https://timetravel.mementoweb.org/api/json/${TimeTravelBot.getCurrentTime()}/${originalUrl}`;
-        console.log(`[TimeTravelBot] Calling GET ${fullUrl}`);
-
-        try {
-            const response = await axios.get(fullUrl);
-            const status = response.status;
-            if (status === 200) {
-                const closest = response.data.mementos.closest;
-                console.log(`[TimeTravelBot] Success on GET ${fullUrl}:\n${JSON.stringify(closest)}`);
-
-                let found = null;
-                for (const priorityHost of this.config.priority) {
-                    for (const archiveStr of closest.uri) {
-                        const archiveUrl = new URL(archiveStr);
-                        if (archiveUrl.hostname === priorityHost.trim()) {
-                            found = archiveStr;
-                            break;
-                        }
-                    }
-                }
-
-                if (found === null) {
-                    found = closest.uri[0];
-                }
-
-                return TimeTravelBot.createSuccessEmbed(originalUrl, found, closest.datetime);
-            } else {
-                console.log(`[TimeTravelBot] Nothing found on GET ${fullUrl}`);
-                return TimeTravelBot.createFailedEmbed(originalUrl, "No Mementos found.");
-            }
-        } catch (error) {
-            if (axios.isAxiosError(error) && error.response !== undefined) {
-                console.error(`[TimeTravelBot] Axios error while calling GET ${fullUrl}:\n${error.response.status} ${error.response.data}`);
-                return TimeTravelBot.createFailedEmbed(originalUrl, error.response.status);
-            } else {
-                console.error(`[TimeTravelBot] Non-Axios error while calling GET ${fullUrl}:\n${error}`);
-                return TimeTravelBot.createFailedEmbed(originalUrl, error);
-            }
+            await interaction.editReply(TimeTravelBot.createFallbackEmbed(url, null));
         }
     }
 
     async handleContextCommand(interaction: MessageContextMenuCommandInteraction): Promise<void> {
         const content = interaction.targetMessage.content;
         console.log(`[TimeTravelBot] Got handleContextCommand() for message: ${content}`);
+        const linkifyResults = find(content, "url");
+        if (linkifyResults.length === 0) {
+            await interaction.reply({
+                embeds: [TimeTravelBot.createInvalidEmbed("No URLs Found", null)],
+                ephemeral: true
+            });
+            return;
+        }
+
         const embed = new EmbedBuilder()
             .setTitle("Processing time travel for the URLs of the target message")
-            .addFields({ name: "Target Message:", value: interaction.targetMessage.url })
+            .addFields(
+                { name: "Target Message", value: interaction.targetMessage.url },
+                { name: "URL Count", value: linkifyResults.length.toString() }
+            )
             .setColor(0xFFFFFF);
-        const reply = await interaction.reply({ embeds: [embed] });
-        const urlCount = await this.handleAuto(interaction.targetMessage, true);
-        if (urlCount === 0) {
-            embed
-                .setDescription("No valid URLs found.")
-                .setColor(0xFF0000);
-            await interaction.editReply({ embeds: [embed] });
+        await interaction.reply({ embeds: [embed] });
+        try {
+            await this.handleAuto(interaction.targetMessage, true);
+        } catch (error) {
+            console.error(`[TimeTravelBot] Got error handling context command:\n${error}`);
+            await interaction.editReply({
+                embeds: [TimeTravelBot.createInvalidEmbed("Unable to complete context menu command", null)]
+            });
         }
     }
 
-    async handleAuto(message: Message, contextMenu: boolean): Promise<number> {
+    async handleAuto(message: Message, contextMenu: boolean): Promise<void> {
         try {
             const content = message.content;
 
             const linkifyResults = find(content, "url");
             if (linkifyResults.length === 0) {
-                return 0;
+                return;
             }
 
             const urls = new Set<string>();
             for (const result of linkifyResults) {
                 try {
                     const url = new URL(result.href);
-                    if (url.pathname === "/") {
-                        continue;
-                    }
-
                     let hostname = url.hostname;
                     if (hostname.startsWith("www.")) {
                         hostname = hostname.substring(4);
                     }
 
-                    if (contextMenu || this.config.allowlist[hostname]) {
+                    if (contextMenu) {
                         urls.add(result.href);
+                        continue;
                     }
+
+                    if (!this.config.allowlist[hostname] || url.pathname === "/") {
+                        continue;
+                    }
+
+                    urls.add(result.href);
                 } catch (error) {
-                    console.error(`[TimeTravelBot] Ignoring error: ${error}`);
+                    console.error(`[TimeTravelBot] Ignoring error for URL ${result.href}:\n${error}`);
                     continue;
                 }
             }
 
             if (urls.size === 0) {
-                return 0;
+                return;
             }
 
             console.log(`[TimeTravelBot] handleAuto() May have found URLs: ${JSON.stringify(Array.from(urls))}`);
-
             for (const url of urls) {
-                const holdEmbed = await TimeTravelBot.createHoldEmbed(url);
-                const replyMsg = await message.reply({
-                    embeds: [holdEmbed],
-                    allowedMentions: {
-                        repliedUser: false
-                    }
-                });
+                const holdEmbed = TimeTravelBot.createHoldEmbed(url);
+                const replyMsg = await message.reply(holdEmbed);
 
                 try {
-                    const replyEmbed = await this.timeTravel(url);
-                    await replyMsg.edit({
-                        embeds: [replyEmbed],
-                        allowedMentions: {
-                            repliedUser: false
-                        }
-                    });
+                    const replyResult = await this.timeTravel(url);
+                    await replyMsg.edit(replyResult);
                 } catch (error) {
-                    console.error(`[TimeTravelBot] Error in auto while calling timeTravel(): ${error}`);
-                    await replyMsg.edit({
-                        embeds: [TimeTravelBot.createFailedEmbed(url, error)]
-                    });
+                    console.error(`[TimeTravelBot] Error in auto while calling timeTravel() for url ${url}:\n${error}`);
+                    await replyMsg.edit(TimeTravelBot.createFallbackEmbed(url, null));
                 }
-                await new Promise(resolve => setTimeout(resolve, 2000)); // rate limit if we move too fast
+                await new Promise(resolve => setTimeout(resolve, TimeTravelBot.AUTO_TIMEOUT)); // rate limit if we move too fast
             }
 
             console.log("[TimeTravelBot] handleAuto() finished");
-            return urls.size;
         } catch (error) {
             console.error(`[TimeTravelBot] Ran into error in handleAuto(), ignoring: ${error}`);
-            return 0;
         }
+    }
+
+    async timeTravel(originalUrl: string): Promise<BaseMessageOptions> {
+        console.log(`[TimeTravelBot] Attempting to time travel ${originalUrl}`);
+        const processor = new TimeTravelProcessor(originalUrl);
+
+        let result: TimeTravelProcessorResult | null = null;
+        try {
+            result = await processor.beginProcessing();
+        } catch (error) {
+            console.error(`[TimeTravelBot] Error in timeTravel():\n${error}`);
+            result = null;
+        }
+
+        if (result === null) {
+            console.error(`[TimeTravelBot] Got null result for ${originalUrl}`);
+            return TimeTravelBot.createFallbackEmbed(originalUrl, processor.getFallbackUrl());
+        }
+
+        console.log(`[TimeTravelBot] timeTravel() processor for ${originalUrl} returned result:\n${JSON.stringify(result, null, 2)}`);
+        if (result.foundUrl !== null && result.depotUsedName !== null) {
+            return TimeTravelBot.createMementoEmbed(originalUrl,
+                result.depotUsedName, result.foundUrl, null, false,
+                null, null, result.datetime);
+        } else if (result.submittedUrl !== null && result.submittedName !== null) {
+            return TimeTravelBot.createMementoEmbed(originalUrl,
+                result.submittedName, result.submittedUrl, "Did not find a Memento, so just submitted a new request to save.", true,
+                null, null, result.datetime);
+        }
+
+        console.error(`[TimeTravelBot] timeTravel() processor for ${originalUrl} returned malformed result:\n${JSON.stringify(result, null, 2)}`);
+        return TimeTravelBot.createFallbackEmbed(originalUrl, processor.getFallbackUrl());
     }
 
     async init(): Promise<string | null> {
         try {
             this.config = await readYamlConfig<TimeTravelConfig>(import.meta, "config.yaml");
+            TimeTravelProcessor.init(this.config);
         } catch (error) {
             const errMsg = `[TimeTravelBot] Unable to read config: ${error}`;
             console.error(errMsg);
@@ -243,49 +239,119 @@ export class TimeTravelBot implements BotInterface {
             .replace(/:/g, "");
     }
 
-    static createHoldEmbed(url: string): EmbedBuilder {
-        return new EmbedBuilder()
-            .setTitle("Time traveling, please hold...")
-            .setColor(0x8C8F91)
-            .addFields({ name: "Original URL", value: url });
+    static dateToTimeStr(date: Date | null): string {
+        if (date !== null) {
+            return date.toLocaleString("en-US");
+        } else {
+            return "Time unknown";
+        }
     }
 
-    static createSuccessEmbed(originalUrl: string, mementoUrl: string, datetime: string): EmbedBuilder {
-        return new EmbedBuilder()
-            .setTitle("Time travel successful")
-            .setColor(0x00FF00)
-            .addFields(
-                { name: "Memento URL", value: mementoUrl },
-                { name: "Original URL", value: originalUrl }
-            )
-            .setFooter({ text: `Timestamp of Memento: ${datetime}` });
+    static createHoldEmbed(url: string): BaseMessageOptions {
+        return {
+            embeds: [new EmbedBuilder()
+                .setTitle("Time traveling, please hold...")
+                .setColor(0x8C8F91)
+                .addFields({ name: "Original URL", value: url })]
+        };
     }
 
-    static createFailedEmbed(url: string, error: unknown = null): EmbedBuilder {
-        let reason = "Unknown error. Bot owner should check logs.";
-        if (error instanceof Error) {
-            reason = error.message;
-        } else if (typeof error === "string") {
-            reason = error;
-        } else if (typeof error === "number") {
-            reason = error.toString();
+    static createFallbackEmbed(originalUrl: string, fallbackUrl: string | null): BaseMessageOptions {
+        return TimeTravelBot.createMementoEmbed(originalUrl,
+            "Fallback URL", fallbackUrl !== null ? fallbackUrl : TimeTravelProcessor.getFallbackUrl(originalUrl),
+            "Ran into an error while time traveling. The above URL should still let you get the latest snapshot.",
+            false, null, null, null);
+    }
+
+    static createMementoEmbed(originalUrl: string,
+        mementoDepotName: string, mementoUrl: string, mementoReason: string | null, wasSubmitted: boolean,
+        userUrl: string | null, user: User | null,
+        datetime: Date | null): BaseMessageOptions {
+
+        let embedColor = TimeTravelBot.COLOR_SUCCESS;
+        const fields: APIEmbedField[] = [];
+
+        let mementoFieldValue = mementoUrl;
+        if (mementoReason !== null) {
+            mementoFieldValue += `\n${italic(mementoReason)}`;
+            if (!wasSubmitted) {
+                embedColor = TimeTravelBot.COLOR_FALLBACK;
+            }
+        }
+        fields.push({ name: `${mementoDepotName} URL`, value: mementoFieldValue });
+
+        let userUrlDeleteBtn: ButtonBuilder | null = null;
+        if (userUrl !== null && user !== null) {
+            fields.push({
+                name: "User Provided URL",
+                value: `${userUrl}\n${italic("Submitted by " + user.toString())}`
+            });
+            userUrlDeleteBtn = TimeTravelBot.createUserUrlDeleteButton();
+
+            if (embedColor === TimeTravelBot.COLOR_FALLBACK) {
+                embedColor = TimeTravelBot.COLOR_USER_ONLY;
+            }
         }
 
-        return new EmbedBuilder()
-            .setTitle("Error while time traveling")
-            .setColor(0xFF0000)
-            .addFields(
-                { name: "Reason", value: reason },
-                { name: "Original URL", value: url }
-            );
+        fields.push({ name: "Original URL", value: originalUrl });
+
+        const embed = new EmbedBuilder()
+            .setTitle("Time travel complete")
+            .setColor(embedColor)
+            .addFields(fields)
+            .setFooter({ text: `Timestamp: ${TimeTravelBot.dateToTimeStr(datetime)}` });
+
+        const actionRow = new ActionRowBuilder() as ActionRowBuilder<ButtonBuilder>;
+        actionRow.addComponents(TimeTravelBot.createUserUrlSubmitButton());
+        if (userUrlDeleteBtn !== null) {
+            actionRow.addComponents(userUrlDeleteBtn);
+        }
+
+        return {
+            embeds: [embed],
+            components: [actionRow],
+            allowedMentions: {
+                repliedUser: false
+            }
+        };
     }
 
-    static isValidUrl(url: string): boolean {
+    static createInvalidEmbed(title: string, url: string | null): EmbedBuilder {
+        const embed = new EmbedBuilder()
+            .setTitle(title)
+            .setColor(0xFF0000);
+        if (url !== null) {
+            embed.addFields({ name: "Provided URL", value: url });
+        }
+
+        return embed;
+    }
+
+    static createUserUrlSubmitButton(): ButtonBuilder {
+        return new ButtonBuilder()
+            .setCustomId(TimeTravelBot.BTN_USER_URL_MODAL)
+            .setLabel("Provide user URL")
+            .setStyle(ButtonStyle.Secondary);
+    }
+
+    static createUserUrlDeleteButton(): ButtonBuilder {
+        return new ButtonBuilder()
+            .setCustomId(TimeTravelBot.BTN_USER_URL_DELETE)
+            .setLabel("Delete user provided URL")
+            .setStyle(ButtonStyle.Danger);
+    }
+
+    static getValidUrl(url: string): string | null {
         try {
-            new URL(url);
-            return true;
+            let returnUrl = url.trim();
+            if (!returnUrl.startsWith("http://") || !returnUrl.startsWith("https://")) {
+                returnUrl = `https://${returnUrl}`;
+            }
+
+            new URL(returnUrl);
+            return returnUrl;
         } catch {
-            return false;
+            return null;
         }
     }
 }

--- a/TimeTravelConfig.ts
+++ b/TimeTravelConfig.ts
@@ -3,5 +3,10 @@ export type TimeTravelConfig = {
     allowlist: {
         [domain: string]: boolean
     },
-    priority: string[]
+    mementoDepots: {
+        [depotName: string]: {
+            timeGate: string,
+            fallback: string | null
+        }
+    }
 }

--- a/TimeTravelConfig.ts
+++ b/TimeTravelConfig.ts
@@ -1,5 +1,6 @@
 export type TimeTravelConfig = {
     autoTimeTravel: boolean,
+    axiosUserAgent: string | null,
     allowlist: {
         [domain: string]: boolean
     },

--- a/TimeTravelProcessor.ts
+++ b/TimeTravelProcessor.ts
@@ -1,11 +1,23 @@
+import { EventEmitter } from "node:events";
 import { TimeTravelConfig } from "./TimeTravelConfig";
 import { Memento, MementoDepot } from "./archivers/MementoDepot";
 import { ArchiveTodaySubmission } from "./archivers/ArchiveTodaySubmission";
+import { InternetArchiveSubmission } from "./archivers/InternetArchiveSubmission";
+import { IArchiveSubmission } from "./archivers/IArchiveSubmission";
 
 export class TimeTravelProcessorError extends Error {
+    private statusCode = -1;
     constructor(message: string) {
         super(message);
         this.name = "TimeTravelProcessorError";
+    }
+
+    getStatusCode(): number {
+        return this.statusCode;
+    }
+
+    setStatusCode(statusCode: number): void {
+        this.statusCode = statusCode;
     }
 }
 
@@ -18,9 +30,16 @@ export type TimeTravelProcessorResult = {
     datetime: Date | null
 }
 
+export type TimeTravelProcessorSubmissionEvent = {
+    originalUrl: string,
+    submittedName: string
+};
+
 export class TimeTravelProcessor {
     private static readonly DEFAULT_FALLBACK_URL_PREFIX = "https://archive.today/newest/";
+    private static readonly SUBMISSION_TIMEOUT = 3000;
 
+    private static userAgent: string | null;
     private static fallbackDepot: MementoDepot | null;
     private static depots: {
         [depotName: string]: MementoDepot
@@ -38,48 +57,80 @@ export class TimeTravelProcessor {
         console.log(`[TimeTravelProcessor] constructor for url ${originalUrlStr}, formattedUrl is ${this.formattedUrl}`);
     }
 
-    async beginProcessing(): Promise<TimeTravelProcessorResult> {
+    async process(eventEmitter: EventEmitter, emitterId: string): Promise<TimeTravelProcessorResult> {
         console.log(`[TimeTravelProcessor] beginProcessing() for url ${this.formattedUrl}`);
 
         // try search through depots
-        let got404 = false;
+        let shouldSubmit = false;
         for (const depotName in TimeTravelProcessor.depots) {
             try {
-                return await this.useSpecificDepotByName(depotName);
+                return await this.useSpecificDepot(depotName);
             } catch (error) {
+                console.error(`[TimeTravelProcessor] beginProcessing() error while using depot ${depotName}:\n${error}`);
                 if (error instanceof TimeTravelProcessorError) {
-                    if (error.message.includes("404")) {
-                        got404 = true;
+                    if (error.getStatusCode() >= 300 && error.getStatusCode() < 500) {
+                        shouldSubmit = true;
                     }
                 }
             }
         }
 
-        if (!got404) {
-            const errStr = `[TimeTravelProcessor] Unable to find any mementos for url ${this.formattedUrl}`;
+        if (!shouldSubmit) {
+            const errStr = `[TimeTravelProcessor] Unable to find any mementos for url ${this.formattedUrl} and did not get a 404`;
             console.error(errStr);
             throw new TimeTravelProcessorError(errStr);
         }
 
         // attempt to submit to archive.today
         try {
-            const submission = new ArchiveTodaySubmission(this.formattedUrl);
-            const result = await submission.submit();
-            const currentDate = new Date();
-            if (!result.isDone) {
-                const errStr = `[TimeTravelProcessor] Unable to submit to archive.today for url ${this.formattedUrl}, got status code ${result.statusCode}`;
-                console.error(errStr);
-                throw new TimeTravelProcessorError(errStr);
+            const submitters: IArchiveSubmission[] = [
+                new ArchiveTodaySubmission(this.formattedUrl, TimeTravelProcessor.userAgent),
+                new InternetArchiveSubmission(this.formattedUrl, TimeTravelProcessor.userAgent)
+            ];
+
+            for (const submitter of submitters) {
+                try {
+                    console.log(`[TimeTravelProcessor] beginProcessing() submitting to ${submitter.name} for url ${this.formattedUrl}`);
+                    const emitterEvent: TimeTravelProcessorSubmissionEvent = {
+                        originalUrl: this.formattedUrl,
+                        submittedName: submitter.name
+                    };
+                    eventEmitter.emit(emitterId, emitterEvent);
+
+                    let result = await submitter.submit();
+                    let isDone = result.isDone;
+                    while (!isDone) {
+                        if (submitter.waitBetweenStatus !== null) {
+                            await new Promise(resolve => setTimeout(resolve, submitter.waitBetweenStatus!));
+                        }
+
+                        console.log(`[TimeTravelProcessor] beginProcessing() checking status of ${submitter.name} for url ${this.formattedUrl}`);
+                        result = await submitter.checkStatus();
+                        isDone = result.isDone;
+                    }
+
+                    if (result.finalUrl === null) {
+                        console.error(`[TimeTravelProcessor] Unable to submit to ${submitter.name} for url ${this.formattedUrl}, got status code ${result.statusCode}`);
+                        continue;
+                    }
+
+                    return {
+                        originalUrl: this.formattedUrl,
+                        depotUsedName: null,
+                        foundUrl: null,
+                        submittedUrl: result.finalUrl,
+                        submittedName: submitter.name,
+                        datetime: result.datetime
+                    };
+                } catch (error) {
+                    console.error(`[TimeTravelProcessor] Error while trying to submit to ${submitter.name} for url ${this.formattedUrl}:\n${error}`);
+                    continue;
+                }
             }
 
-            return {
-                originalUrl: this.formattedUrl,
-                foundUrl: null,
-                depotUsedName: null,
-                submittedUrl: result.finalUrl,
-                submittedName: submission.name,
-                datetime: currentDate
-            };
+            const errStr = `[TimeTravelProcessor] Unable to submit to any archive for url ${this.formattedUrl}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
         } catch (error) {
             if (error instanceof TimeTravelProcessorError) {
                 throw error;
@@ -94,7 +145,7 @@ export class TimeTravelProcessor {
     /**
      * @throws {TimeTravelProcessorError}
      */
-    async useSpecificDepotByName(depotName: string): Promise<TimeTravelProcessorResult> {
+    async useSpecificDepot(depotName: string): Promise<TimeTravelProcessorResult> {
         const depot = TimeTravelProcessor.depots[depotName];
         if (depot === undefined) {
             const errStr = `[TimeTravelProcessor] Could not find depot ${depotName} for url ${this.formattedUrl}`;
@@ -113,9 +164,11 @@ export class TimeTravelProcessor {
         }
 
         if (result.status >= 400 || result.url === null) {
-            const errStr = `[TimeTravelProcessor] Got status code ${result.status} from ${depotName} for url ${this.formattedUrl}`;
+            const errStr = `${result.status}: [TimeTravelProcessor] Got status code ${result.status} from ${depotName} for url ${this.formattedUrl}`;
             console.error(errStr);
-            throw new TimeTravelProcessorError(errStr);
+            const statusError = new TimeTravelProcessorError(errStr);
+            statusError.setStatusCode(result.status);
+            throw statusError;
         }
 
         return {
@@ -144,9 +197,10 @@ export class TimeTravelProcessor {
     }
 
     static init(config: TimeTravelConfig): void {
+        TimeTravelProcessor.userAgent = config.axiosUserAgent;
         for (const depotName in config.mementoDepots) {
             const depotConfig = config.mementoDepots[depotName];
-            const depot = new MementoDepot(depotConfig.timeGate, depotConfig.fallback);
+            const depot = new MementoDepot(depotConfig.timeGate, depotConfig.fallback, config.axiosUserAgent);
             TimeTravelProcessor.depots[depotName] = depot;
             if (depotConfig.fallback !== null && TimeTravelProcessor.fallbackDepot !== null) {
                 TimeTravelProcessor.fallbackDepot = depot;

--- a/TimeTravelProcessor.ts
+++ b/TimeTravelProcessor.ts
@@ -1,0 +1,156 @@
+import { TimeTravelConfig } from "./TimeTravelConfig";
+import { Memento, MementoDepot } from "./archivers/MementoDepot";
+import { ArchiveTodaySubmission } from "./archivers/ArchiveTodaySubmission";
+
+export class TimeTravelProcessorError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TimeTravelProcessorError";
+    }
+}
+
+export type TimeTravelProcessorResult = {
+    originalUrl: string,
+    foundUrl: string | null,
+    depotUsedName: string | null,
+    submittedUrl: string | null,
+    submittedName: string | null,
+    datetime: Date | null
+}
+
+export class TimeTravelProcessor {
+    private static readonly DEFAULT_FALLBACK_URL_PREFIX = "https://archive.today/newest/";
+
+    private static fallbackDepot: MementoDepot | null;
+    private static depots: {
+        [depotName: string]: MementoDepot
+    } = {};
+
+    private readonly originalUrlStr: string;
+    private readonly formattedUrl: string;
+
+    constructor(originalUrlStr: string) {
+        this.originalUrlStr = originalUrlStr;
+        const formattedUrlObj = new URL(originalUrlStr);
+        formattedUrlObj.search = "";
+        formattedUrlObj.hash = "";
+        this.formattedUrl = formattedUrlObj.toString();
+        console.log(`[TimeTravelProcessor] constructor for url ${originalUrlStr}, formattedUrl is ${this.formattedUrl}`);
+    }
+
+    async beginProcessing(): Promise<TimeTravelProcessorResult> {
+        console.log(`[TimeTravelProcessor] beginProcessing() for url ${this.formattedUrl}`);
+
+        // try search through depots
+        let got404 = false;
+        for (const depotName in TimeTravelProcessor.depots) {
+            try {
+                return await this.useSpecificDepotByName(depotName);
+            } catch (error) {
+                if (error instanceof TimeTravelProcessorError) {
+                    if (error.message.includes("404")) {
+                        got404 = true;
+                    }
+                }
+            }
+        }
+
+        if (!got404) {
+            const errStr = `[TimeTravelProcessor] Unable to find any mementos for url ${this.formattedUrl}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
+        }
+
+        // attempt to submit to archive.today
+        try {
+            const submission = new ArchiveTodaySubmission(this.formattedUrl);
+            const result = await submission.submit();
+            const currentDate = new Date();
+            if (!result.isDone) {
+                const errStr = `[TimeTravelProcessor] Unable to submit to archive.today for url ${this.formattedUrl}, got status code ${result.statusCode}`;
+                console.error(errStr);
+                throw new TimeTravelProcessorError(errStr);
+            }
+
+            return {
+                originalUrl: this.formattedUrl,
+                foundUrl: null,
+                depotUsedName: null,
+                submittedUrl: result.finalUrl,
+                submittedName: submission.name,
+                datetime: currentDate
+            };
+        } catch (error) {
+            if (error instanceof TimeTravelProcessorError) {
+                throw error;
+            }
+
+            const errStr = `[TimeTravelProcessor] Error while trying to submit to archive.today for url ${this.formattedUrl}:\n${error}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
+        }
+    }
+
+    /**
+     * @throws {TimeTravelProcessorError}
+     */
+    async useSpecificDepotByName(depotName: string): Promise<TimeTravelProcessorResult> {
+        const depot = TimeTravelProcessor.depots[depotName];
+        if (depot === undefined) {
+            const errStr = `[TimeTravelProcessor] Could not find depot ${depotName} for url ${this.formattedUrl}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
+        }
+
+        console.log(`[TimeTravelProcessor] useSpecificDepot() ${depotName} for url ${this.formattedUrl}`);
+        let result: Memento;
+        try {
+            result = await depot.getLatestMemento(this.formattedUrl);
+        } catch (error) {
+            const errStr = `[TimeTravelProcessor] Error calling getLatestMemento() on ${depotName} for url ${this.formattedUrl}:\n${error}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
+        }
+
+        if (result.status >= 400 || result.url === null) {
+            const errStr = `[TimeTravelProcessor] Got status code ${result.status} from ${depotName} for url ${this.formattedUrl}`;
+            console.error(errStr);
+            throw new TimeTravelProcessorError(errStr);
+        }
+
+        return {
+            originalUrl: this.originalUrlStr,
+            depotUsedName: depotName,
+            foundUrl: result.url,
+            submittedUrl: null,
+            submittedName: null,
+            datetime: result.datetime
+        };
+    }
+
+    getFallbackUrl(): string {
+        return TimeTravelProcessor.getFallbackUrl(this.formattedUrl);
+    }
+
+    static getFallbackUrl(url: string): string {
+        if (TimeTravelProcessor.fallbackDepot !== null) {
+            const fallbackUrl = TimeTravelProcessor.fallbackDepot.getFallbackUrl(url);
+            if (fallbackUrl !== null) {
+                return fallbackUrl;
+            }
+        }
+
+        return `${TimeTravelProcessor.DEFAULT_FALLBACK_URL_PREFIX}${url}`;
+    }
+
+    static init(config: TimeTravelConfig): void {
+        for (const depotName in config.mementoDepots) {
+            const depotConfig = config.mementoDepots[depotName];
+            const depot = new MementoDepot(depotConfig.timeGate, depotConfig.fallback);
+            TimeTravelProcessor.depots[depotName] = depot;
+            if (depotConfig.fallback !== null && TimeTravelProcessor.fallbackDepot !== null) {
+                TimeTravelProcessor.fallbackDepot = depot;
+            }
+        }
+    }
+}

--- a/archivers/ArchiveTodaySubmission.ts
+++ b/archivers/ArchiveTodaySubmission.ts
@@ -1,0 +1,50 @@
+import { ArchiveSubmissionResult, IArchiveSubmission } from "./IArchiveSubmission";
+import axios from "axios";
+
+export class ArchiveTodaySubmission implements IArchiveSubmission {
+    readonly name: string;
+    readonly originalUrl: string;
+    private wipUrl: string | null;
+    private statusCode: number | null;
+
+    constructor(url: string) {
+        console.log(`[ArchiveTodaySubmission] constructor for url ${url}`);
+        this.name = "archive.today";
+        this.originalUrl = url;
+        this.wipUrl = null;
+        this.statusCode = null;
+    }
+
+    async submit(): Promise<ArchiveSubmissionResult> {
+        const fullUrl = `https://archive.today/submit/?url=${this.originalUrl}`;
+        console.log(`[ArchiveTodaySubmission] Calling submit() using url ${fullUrl}`);
+        const response = await axios.get(fullUrl, { validateStatus: () => true });
+        this.statusCode = response.status;
+        if (this.statusCode >= 400) {
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: false,
+                finalUrl: null
+            };
+        }
+
+        const refreshHeader = response.headers["refresh"] as string;
+        this.wipUrl = refreshHeader.substring(refreshHeader.indexOf("url=") + 4);
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: true,
+            finalUrl: this.wipUrl
+        };
+    }
+
+    async checkStatus(): Promise<ArchiveSubmissionResult> {
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: this.wipUrl !== null,
+            finalUrl: this.wipUrl
+        };
+    }
+}

--- a/archivers/ArchiveTodaySubmission.ts
+++ b/archivers/ArchiveTodaySubmission.ts
@@ -1,41 +1,73 @@
 import { ArchiveSubmissionResult, IArchiveSubmission } from "./IArchiveSubmission";
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 
 export class ArchiveTodaySubmission implements IArchiveSubmission {
     readonly name: string;
     readonly originalUrl: string;
+    readonly userAgent: string | null;
+    readonly waitBetweenStatus = null;
     private wipUrl: string | null;
     private statusCode: number | null;
+    private isDone = false;
+    private dateTime: Date | null = null;
 
-    constructor(url: string) {
+    constructor(url: string, userAgent: string | null) {
         console.log(`[ArchiveTodaySubmission] constructor for url ${url}`);
         this.name = "archive.today";
         this.originalUrl = url;
         this.wipUrl = null;
         this.statusCode = null;
+        this.userAgent = userAgent;
     }
 
     async submit(): Promise<ArchiveSubmissionResult> {
         const fullUrl = `https://archive.today/submit/?url=${this.originalUrl}`;
         console.log(`[ArchiveTodaySubmission] Calling submit() using url ${fullUrl}`);
-        const response = await axios.get(fullUrl, { validateStatus: () => true });
-        this.statusCode = response.status;
-        if (this.statusCode >= 400) {
-            return {
-                originalUrl: this.originalUrl,
-                statusCode: this.statusCode,
-                isDone: false,
-                finalUrl: null
+        const axiosConfig: AxiosRequestConfig = {
+            validateStatus: () => true
+        };
+
+        if (this.userAgent !== null) {
+            axiosConfig.headers = {
+                "User-Agent": this.userAgent
             };
         }
 
-        const refreshHeader = response.headers["refresh"] as string;
+        const response = await axios.get(fullUrl, axiosConfig);
+        this.statusCode = response.status;
+        if (this.statusCode >= 400) {
+            this.isDone = true;
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: this.isDone,
+                finalUrl: null,
+                datetime: null
+            };
+        }
+
+        const refreshHeader = response.headers["refresh"];
+        if (refreshHeader === undefined) {
+            console.error(`[ArchiveTodaySubmission] could not find refresh header in response:\n${JSON.stringify(response.headers, null, 2)}`);
+            this.isDone = true;
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: this.isDone,
+                finalUrl: null,
+                datetime: null
+            };
+        }
+
         this.wipUrl = refreshHeader.substring(refreshHeader.indexOf("url=") + 4);
+        this.isDone = true;
+        this.dateTime = new Date();
         return {
             originalUrl: this.originalUrl,
             statusCode: this.statusCode,
-            isDone: true,
-            finalUrl: this.wipUrl
+            isDone: this.isDone,
+            finalUrl: this.wipUrl,
+            datetime: this.dateTime
         };
     }
 
@@ -43,8 +75,9 @@ export class ArchiveTodaySubmission implements IArchiveSubmission {
         return {
             originalUrl: this.originalUrl,
             statusCode: this.statusCode,
-            isDone: this.wipUrl !== null,
-            finalUrl: this.wipUrl
+            isDone: this.isDone,
+            finalUrl: this.wipUrl,
+            datetime: this.dateTime
         };
     }
 }

--- a/archivers/IArchiveSubmission.ts
+++ b/archivers/IArchiveSubmission.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-vars */
+
+export type ArchiveSubmissionResult = {
+    originalUrl: string,
+    statusCode: number | null,
+    isDone: boolean,
+    finalUrl: string | null
+};
+
+/**
+ * @throws {NoResubmitError}
+ */
+export interface IArchiveSubmission {
+    readonly name: string;
+    readonly originalUrl: string;
+    submit(): Promise<ArchiveSubmissionResult>;
+    checkStatus(): Promise<ArchiveSubmissionResult>;
+}

--- a/archivers/IArchiveSubmission.ts
+++ b/archivers/IArchiveSubmission.ts
@@ -4,7 +4,8 @@ export type ArchiveSubmissionResult = {
     originalUrl: string,
     statusCode: number | null,
     isDone: boolean,
-    finalUrl: string | null
+    finalUrl: string | null,
+    datetime: Date | null
 };
 
 /**
@@ -13,6 +14,8 @@ export type ArchiveSubmissionResult = {
 export interface IArchiveSubmission {
     readonly name: string;
     readonly originalUrl: string;
+    readonly userAgent: string | null;
+    readonly waitBetweenStatus: number | null;
     submit(): Promise<ArchiveSubmissionResult>;
     checkStatus(): Promise<ArchiveSubmissionResult>;
 }

--- a/archivers/InternetArchiveSubmission.ts
+++ b/archivers/InternetArchiveSubmission.ts
@@ -1,0 +1,106 @@
+import { ArchiveSubmissionResult, IArchiveSubmission } from "./IArchiveSubmission";
+import axios from "axios";
+
+export class InternetArchiveSubmission implements IArchiveSubmission {
+    private static readonly JOB_REGEX = new RegExp(String.raw`Job\("([^ ",\\/:]+)",`, "i");
+
+    readonly name: string;
+    readonly originalUrl: string;
+    private jobId: string | null;
+    private timestamp: string | null;
+    private statusCode: number | null;
+
+    constructor(url: string) {
+        console.log(`[InternetArchiveSubmission] constructor for url ${url}`);
+        this.name = "Internet Archive";
+        this.originalUrl = url;
+        this.jobId = null;
+        this.timestamp = null;
+        this.statusCode = null;
+    }
+
+    async submit(): Promise<ArchiveSubmissionResult> {
+        const fullUrl = `https://web.archive.org/save/${this.originalUrl}`;
+        const formData = new FormData();
+        formData.append("url", this.originalUrl);
+        formData.append("capture_all", "on");
+
+        console.log(`[InternetArchiveSubmission] Calling submit() using url ${fullUrl}`);
+        const response = await axios.post(fullUrl, { validateStatus: () => true });
+        this.statusCode = response.status;
+        if (this.statusCode !== 200) {
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: false,
+                finalUrl: null
+            };
+        }
+
+        const responseStr = response.data as string;
+        const regexMatches = responseStr.match(InternetArchiveSubmission.JOB_REGEX);
+        if (regexMatches === null || regexMatches.length === 0) {
+            const errStr = `[InternetArchiveSubmission] Unable to find job ID in response: ${responseStr}`;
+            console.error(errStr);
+            throw new Error(errStr);
+        }
+
+        this.jobId = regexMatches[1];
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: false,
+            finalUrl: null
+        };
+    }
+
+    async checkStatus(): Promise<ArchiveSubmissionResult> {
+        if (this.timestamp !== null) {
+            const mementoUrl = this.timestampToMementoUrl();
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: true,
+                finalUrl: mementoUrl
+            };
+        }
+
+        const fullUrl = `https://web.archive.org/save/status/${this.jobId}`;
+        console.log(`[InternetArchiveSubmission] Calling checkStatus() using url ${fullUrl}`);
+        const response = await axios.get(fullUrl, { validateStatus: () => true });
+        this.statusCode = response.status;
+        if (this.statusCode !== 200) {
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: false,
+                finalUrl: null
+            };
+        }
+
+        const responseObj = JSON.parse(response.data as string);
+        const status = responseObj.status as string;
+        if (status !== "success") {
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: false,
+                finalUrl: null
+            };
+        }
+
+        const timestamp = responseObj.timestamp as string;
+        this.timestamp = timestamp;
+        const mementoUrl = this.timestampToMementoUrl();
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: true,
+            finalUrl: mementoUrl
+        };
+    }
+
+    timestampToMementoUrl(): string {
+        return `https://web.archive.org/web/${this.timestamp}/${this.originalUrl}`;
+    }
+}

--- a/archivers/InternetArchiveSubmissionJob.ts
+++ b/archivers/InternetArchiveSubmissionJob.ts
@@ -1,0 +1,170 @@
+import { ArchiveSubmissionResult, IArchiveSubmission } from "./IArchiveSubmission";
+import axios, { AxiosRequestConfig } from "axios";
+import { MementoDepot } from "./MementoDepot";
+
+/**
+ * test using POST + form data, and querying job status
+ */
+export class InternetArchiveSubmissionJob implements IArchiveSubmission {
+    private static readonly JOB_REGEX = new RegExp(String.raw`Job\("([^ ",\\/:]+)",`, "i");
+
+    readonly name: string;
+    readonly originalUrl: string;
+    readonly userAgent: string | null;
+    readonly waitBetweenStatus = 2000;
+    private jobId: string | null;
+    private datetime: Date | null = null;
+    private statusCode: number | null;
+    private isDone = false;
+    private finalUrl: string | null = null;
+
+    constructor(url: string, userAgent: string | null) {
+        console.log(`[InternetArchiveSubmission] constructor for url ${url}`);
+        this.name = "Internet Archive";
+        this.originalUrl = url;
+        this.jobId = null;
+        this.statusCode = null;
+        this.userAgent = userAgent;
+    }
+
+    async submit(): Promise<ArchiveSubmissionResult> {
+        const fullUrl = `https://web.archive.org/save/${this.originalUrl}`;
+        const formData = new FormData();
+        formData.append("url", this.originalUrl);
+        formData.append("capture_all", "on");
+
+        console.log(`[InternetArchiveSubmission] Calling submit() using url ${fullUrl}`);
+        const axiosConfig: AxiosRequestConfig = {
+            validateStatus: () => true
+        };
+
+        if (this.userAgent !== null) {
+            axiosConfig.headers = {
+                "User-Agent": this.userAgent
+            };
+        }
+
+        const response = await axios.post(fullUrl, formData, axiosConfig);
+        this.statusCode = response.status;
+        if (this.statusCode >= 300) {
+            this.isDone = true;
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: true,
+                finalUrl: null,
+                datetime: null
+            };
+        }
+
+        const responseStr = response.data as string;
+        const regexMatches = responseStr.match(InternetArchiveSubmissionJob.JOB_REGEX);
+        if (regexMatches === null || regexMatches.length === 0) {
+            const errStr = `[InternetArchiveSubmission] Unable to find job ID in response: ${responseStr}`;
+            console.error(errStr);
+            throw new Error(errStr);
+        }
+
+        this.jobId = regexMatches[1];
+        this.isDone = false;
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: false,
+            finalUrl: null,
+            datetime: null
+        };
+    }
+
+    async checkStatus(): Promise<ArchiveSubmissionResult> {
+        if (this.isDone) {
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: true,
+                finalUrl: this.finalUrl,
+                datetime: this.datetime
+            };
+        }
+
+        const fullUrl = `https://web.archive.org/save/status/${this.jobId}`;
+        console.log(`[InternetArchiveSubmission] Calling checkStatus() using url ${fullUrl}`);
+        const axiosConfig: AxiosRequestConfig = {
+            validateStatus: () => true
+        };
+
+        if (this.userAgent !== null) {
+            axiosConfig.headers = {
+                "User-Agent": this.userAgent
+            };
+        }
+
+        const response = await axios.get(fullUrl, axiosConfig);
+        this.statusCode = response.status;
+        if (this.statusCode >= 300) {
+            console.error(`[InternetArchiveSubmission] checkStatus() got status code ${this.statusCode}`);
+            this.isDone = true;
+            this.finalUrl = null;
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: true,
+                finalUrl: null,
+                datetime: null
+            };
+        }
+
+        const responseObj = JSON.parse(response.data as string);
+        const archiveStatus = responseObj.status as string;
+        console.error(`[InternetArchiveSubmission] checkStatus() got status ${archiveStatus}`);
+        if (archiveStatus === "pending") {
+            this.isDone = false;
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: false,
+                finalUrl: null,
+                datetime: null
+            };
+        } else if (archiveStatus === "success") {
+            this.isDone = true;
+            const timestampStr = responseObj.timestamp;
+            if (timestampStr === undefined) {
+                console.error(`[InternetArchiveSubmission] checkStatus() got success but no timestamp:\n${JSON.stringify(response.headers, null, 2)}`);
+                this.finalUrl = null;
+                return {
+                    originalUrl: this.originalUrl,
+                    statusCode: this.statusCode,
+                    isDone: true,
+                    finalUrl: null,
+                    datetime: null
+                };
+            }
+
+            this.datetime = MementoDepot.datetimeStringToDateTime(timestampStr);
+            this.finalUrl = this.timestampToMementoUrl(timestampStr);
+            return {
+                originalUrl: this.originalUrl,
+                statusCode: this.statusCode,
+                isDone: true,
+                finalUrl: this.finalUrl,
+                datetime: this.datetime
+            };
+        }
+
+        console.error(`[InternetArchiveSubmission] checkStatus() got unknown status:\n${JSON.stringify(response.headers, null, 2)}`);
+        this.isDone = true;
+        this.finalUrl = null;
+        return {
+            originalUrl: this.originalUrl,
+            statusCode: this.statusCode,
+            isDone: true,
+            finalUrl: null,
+            datetime: null
+        };
+    }
+
+    timestampToMementoUrl(timestampStr: string): string {
+        return `https://web.archive.org/web/${timestampStr}/${this.originalUrl}`;
+    }
+}

--- a/archivers/MementoDepot.ts
+++ b/archivers/MementoDepot.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
 export type Memento = {
     status: number,
@@ -11,16 +11,28 @@ export class MementoDepot {
 
     private readonly timeGatePrefix: string;
     private readonly fallbackPrefix: string | null;
+    private readonly userAgent: string | null;
 
-    constructor(timeGatePrefix: string, fallbackPrefix: string | null) {
+    constructor(timeGatePrefix: string, fallbackPrefix: string | null, userAgent: string | null) {
         this.timeGatePrefix = timeGatePrefix;
         this.fallbackPrefix = fallbackPrefix;
+        this.userAgent = userAgent;
     }
 
     async getLatestMemento(url: string): Promise<Memento> {
         const fullUrl = `${this.timeGatePrefix}${url}`;
         console.log(`[MementoDepot] Calling getLatestMemento() using url ${fullUrl}`);
-        const response = await axios.get(fullUrl, { validateStatus: () => true });
+        const axiosConfig: AxiosRequestConfig = {
+            validateStatus: () => true
+        };
+
+        if (this.userAgent !== null) {
+            axiosConfig.headers = {
+                "User-Agent": this.userAgent
+            };
+        }
+
+        const response = await axios.get(fullUrl, axiosConfig);
         const status = response.status;
         if (status >= 400) {
             console.error(`[MementoDepot] Got status code ${status} on from ${fullUrl}`);
@@ -31,51 +43,71 @@ export class MementoDepot {
             };
         }
 
-        let mementoUrl: string | undefined = response.headers["location"];
+        const mementoUrl = MementoDepot.parseResponseHeaders(response.headers);
+        return {
+            status: status,
+            url: mementoUrl,
+            datetime: mementoUrl === null ? null : MementoDepot.getDateFromMementoUrl(mementoUrl)
+        };
+    }
+
+    static parseResponseHeaders(headers: AxiosResponse["headers"]): string | null {
+        let mementoUrl: string | undefined = headers["location"];
         if (mementoUrl !== undefined) {
-            console.log(`[MementoDepot] getLatestMemento() got mementoUrl ${mementoUrl} from location header`);
+            console.log(`[MementoDepot] parseResponseHeaders() got mementoUrl ${mementoUrl} from location header`);
+            return mementoUrl;
         } else {
-            const linkHeader: string | undefined = response.headers["link"];
+            const linkHeader: string | undefined = headers["link"];
             if (linkHeader === undefined) {
-                console.error(`[MementoDepot] getLatestMemento() could not determine latest memento or location for ${fullUrl}`);
-                return {
-                    status: status,
-                    url: null,
-                    datetime: null
-                };
+                console.error(`[MementoDepot] parseResponseHeaders() could not determine latest memento or location from headers:\n${JSON.stringify(headers, null, 2)}`);
+                return null;
             }
 
             const linkArray = linkHeader.split(",");
+            if (linkArray.length === 0) {
+                console.error(`[MementoDepot] parseResponseHeaders() got linkHeader.length===0 from headers:\n${JSON.stringify(headers, null, 2)}`);
+                return null;
+            }
+
             for (const entry of linkArray) {
                 // eslint-disable-next-line quotes
-                if (!entry.includes('rel="last memento";')) {
+                if (!entry.includes('rel="last memento"')) {
                     continue;
                 }
 
                 mementoUrl = entry.substring(entry.indexOf("<") + 1, entry.indexOf(">"));
+                console.log(`[MementoDepot] parseResponseHeaders() got mementoUrl ${mementoUrl} from link header`);
+                return mementoUrl;
             }
 
-            console.log(`[MementoDepot] getLatestMemento() got mementoUrl ${mementoUrl} from link header`);
+            // if "last memento" not found, try find a link working backwards
+            if (mementoUrl === undefined) {
+                for (let entryIndex = linkArray.length - 1; entryIndex >= 0; entryIndex--) {
+                    const entry = linkArray[entryIndex];
+                    if (!entry.includes("memento")) {
+                        continue;
+                    }
+
+                    const beginningIndex = entry.indexOf("<");
+                    const endingIndex = entry.indexOf(">");
+                    if (beginningIndex < 0 && endingIndex < 0) {
+                        continue;
+                    }
+
+                    mementoUrl = entry.substring(beginningIndex + 1, endingIndex);
+                    console.log(`[MementoDepot] parseResponseHeaders() got mementoUrl ${mementoUrl} but could not find last memento entry`);
+                    return mementoUrl;
+                }
+            }
+
+            console.log(`[MementoDepot] parseResponseHeaders() got mementoUrl ${mementoUrl} from link header`);
         }
 
-        if (mementoUrl === undefined) {
-            console.error(`[MementoDepot] getLatestMemento() could not determine latest memento or location for ${fullUrl}`);
-            return {
-                status: status,
-                url: null,
-                datetime: null
-            };
-        }
-
-        const mementoDate = this.getDateFromMementoUrl(mementoUrl);
-        return {
-            status: status,
-            url: mementoUrl,
-            datetime: mementoDate
-        };
+        console.error(`[MementoDepot] parseResponseHeaders() could not determine latest memento or location from headers:\n${JSON.stringify(headers, null, 2)}`);
+        return null;
     }
 
-    getDateFromMementoUrl(url: string): Date | null {
+    static getDateFromMementoUrl(url: string): Date | null {
         try {
             const regexMatches = url.match(MementoDepot.MEMENTO_DATETIME_REGEX);
             if (regexMatches === null || regexMatches.length < 1) {

--- a/archivers/MementoDepot.ts
+++ b/archivers/MementoDepot.ts
@@ -1,0 +1,122 @@
+import axios from "axios";
+
+export type Memento = {
+    status: number,
+    url: string | null,
+    datetime: Date | null
+};
+
+export class MementoDepot {
+    private static readonly MEMENTO_DATETIME_REGEX = new RegExp(String.raw`([0-9]{14})`);
+
+    private readonly timeGatePrefix: string;
+    private readonly fallbackPrefix: string | null;
+
+    constructor(timeGatePrefix: string, fallbackPrefix: string | null) {
+        this.timeGatePrefix = timeGatePrefix;
+        this.fallbackPrefix = fallbackPrefix;
+    }
+
+    async getLatestMemento(url: string): Promise<Memento> {
+        const fullUrl = `${this.timeGatePrefix}${url}`;
+        console.log(`[MementoDepot] Calling getLatestMemento() using url ${fullUrl}`);
+        const response = await axios.get(fullUrl, { validateStatus: () => true });
+        const status = response.status;
+        if (status >= 400) {
+            console.error(`[MementoDepot] Got status code ${status} on from ${fullUrl}`);
+            return {
+                status: status,
+                url: null,
+                datetime: null
+            };
+        }
+
+        let mementoUrl: string | undefined = response.headers["location"];
+        if (mementoUrl !== undefined) {
+            console.log(`[MementoDepot] getLatestMemento() got mementoUrl ${mementoUrl} from location header`);
+        } else {
+            const linkHeader: string | undefined = response.headers["link"];
+            if (linkHeader === undefined) {
+                console.error(`[MementoDepot] getLatestMemento() could not determine latest memento or location for ${fullUrl}`);
+                return {
+                    status: status,
+                    url: null,
+                    datetime: null
+                };
+            }
+
+            const linkArray = linkHeader.split(",");
+            for (const entry of linkArray) {
+                // eslint-disable-next-line quotes
+                if (!entry.includes('rel="last memento";')) {
+                    continue;
+                }
+
+                mementoUrl = entry.substring(entry.indexOf("<") + 1, entry.indexOf(">"));
+            }
+
+            console.log(`[MementoDepot] getLatestMemento() got mementoUrl ${mementoUrl} from link header`);
+        }
+
+        if (mementoUrl === undefined) {
+            console.error(`[MementoDepot] getLatestMemento() could not determine latest memento or location for ${fullUrl}`);
+            return {
+                status: status,
+                url: null,
+                datetime: null
+            };
+        }
+
+        const mementoDate = this.getDateFromMementoUrl(mementoUrl);
+        return {
+            status: status,
+            url: mementoUrl,
+            datetime: mementoDate
+        };
+    }
+
+    getDateFromMementoUrl(url: string): Date | null {
+        try {
+            const regexMatches = url.match(MementoDepot.MEMENTO_DATETIME_REGEX);
+            if (regexMatches === null || regexMatches.length < 1) {
+                throw new Error(`No regex matches found for ${url}`);
+            }
+
+            const mementoDateStr = regexMatches[0];
+            return MementoDepot.datetimeStringToDateTime(mementoDateStr);
+        } catch (error) {
+            console.error(`[MementoDepot] Error parsing memento date from url ${url}:\n${error}`);
+            return null;
+        }
+    }
+
+    getFallbackUrl(url: string): string | null {
+        if (this.fallbackPrefix === null) {
+            return null;
+        }
+
+        const fullUrl = `${this.fallbackPrefix}${url}`;
+        console.log(`[MementoDepot] getFallbackUrl() returning url ${fullUrl}`);
+        return fullUrl;
+    }
+
+    static datetimeStringToDateTime(datetimeString: string): Date | null {
+        if (datetimeString.length !== 14) {
+            console.error(`[MementoDepot] Memento date is not 14 characters long, got ${datetimeString}`);
+            return null;
+        }
+
+        try {
+            const year = parseInt(datetimeString.substring(0, 4));
+            const month = parseInt(datetimeString.substring(4, 6));
+            const day = parseInt(datetimeString.substring(6, 8));
+            const hour = parseInt(datetimeString.substring(8, 10));
+            const minute = parseInt(datetimeString.substring(10, 12));
+            const seconds = parseInt(datetimeString.substring(12, 14));
+            return new Date(year, month, day, hour, minute, seconds);
+        } catch (error) {
+            console.error(`[MementoDepot] datetimeStringToDateTime() Error parsing datetime string ${datetimeString}:\n${error}`);
+            return null;
+        }
+    }
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,8 +11,13 @@ allowlist:
   example.com: true
   example.org: true
 
-# Priority archivers
-# Domain only per line
-priority:
-  - archive.today
-  - archive.org
+# Memento API compatible services
+# See: http://mementoweb.org/depot/, include trailing slash
+# fallback is a url that will show a user in their browser the latest available
+mementoDepots:
+  archive.today:
+    timeGate: https://archive.today/timegate/
+    fallback: https://archive.today/newest/
+  Internet Archive:
+    timeGate: https://web.archive.org/web/
+    fallback: https://web.archive.org/web/*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-travel-discord-bot",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "repository": "git@github.com:elliot-gh/Time-Travel-Discord-Bot.git",
   "author": "Elliot",
   "license": "GPL-3.0",
@@ -11,7 +11,7 @@
     "node": ">=18.12.0"
   },
   "dependencies": {
-    "axios": "^1.2.0",
-    "linkifyjs": "^4.0.2"
+    "axios": "^1.3.5",
+    "linkifyjs": "^4.1.1"
   }
 }


### PR DESCRIPTION
The mementoweb.org API calls have been very flaky, returning a lot of 5xx errors recently. This update no longer calls it directly, but instead relies on calling Memento compatible APIs directly (such as the Internet Archive). This has proven to be more reliable, though more suspect to 429s in the case of archive.is. This update also tries to auto submit a 404'd URL to archive.is and then Internet Archive, though archive.is tends to return 429s immediately so it usually ends up just being the Internet Archive. There is a quick auto fallback URL as well, in case all of the above fails. Users can now also submit their own URLs to put in the time travel embed via a modal.